### PR TITLE
Add app colors to preview page and shared

### DIFF
--- a/src/Manifest.elm
+++ b/src/Manifest.elm
@@ -88,7 +88,7 @@ placeholders =
         "/"
         "/"
         "#ffffff"
-        "#dd1111"
+        "#cd0a0a"
         Display.init
         Orientation.init
         []
@@ -99,8 +99,8 @@ placeholders =
         "hr"
         "/"
         "/"
-        "#000000"
-        "#ffffff"
+        "#9cc3d5"
+        "#0063b2"
         Display.init
         Orientation.init
         [ Icon.placeholder ]
@@ -111,8 +111,8 @@ placeholders =
         "gu"
         "/"
         "/"
-        "#111111"
-        "#2222ee"
+        "#000"
+        "#603f83"
         Display.init
         Orientation.init
         [ Icon.placeholder, Icon.placeholder ]

--- a/src/Shared.elm
+++ b/src/Shared.elm
@@ -21,7 +21,7 @@ import Manifest exposing (Manifest)
 import Session exposing (Session)
 import Spa.Document exposing (Document)
 import Spa.Generated.Route as Route
-import UI.Colors as Colors
+import UI.Colors as Colors exposing (Colors)
 import UI.Fonts as Fonts
 import Url exposing (Url)
 
@@ -46,6 +46,7 @@ type alias Model =
     , session : Session
     , device : Device
     , manifests : List Manifest
+    , colors : Colors
     }
 
 
@@ -57,6 +58,7 @@ init flags url key =
         Session.loading
         (classifyDevice flags.window)
         Manifest.placeholders
+        Colors.init
     , Cmd.none
     )
 
@@ -113,15 +115,15 @@ view { page, toMsg } model =
     { title = page.title
     , body =
         [ column
-            [ spacing 20
-            , height fill
+            [ height fill
             , width fill
             ]
             [ row
                 [ width fill
                 , spacing 20
                 , paddingXY 25 30
-                , Background.color Colors.lightPurple
+                , Background.color model.colors.themeColor
+                , Font.color model.colors.themeFontColor
                 ]
                 [ link []
                     { url = Route.toString Route.Top
@@ -134,7 +136,6 @@ view { page, toMsg } model =
                             , el
                                 [ Font.size 28
                                 , Font.family Fonts.workSans
-                                , Font.color Colors.darkGray
                                 ]
                                 (text "Fission PWA Generator")
                             ]
@@ -142,7 +143,12 @@ view { page, toMsg } model =
                 , viewSignInButton
                     { session = model.session, toMsg = toMsg }
                 ]
-            , column [ width fill, height fill ] page.body
+            , column
+                [ width fill
+                , height fill
+                , Background.color model.colors.backgroundColor
+                ]
+                page.body
             ]
         ]
     }

--- a/src/UI/Colors.elm
+++ b/src/UI/Colors.elm
@@ -1,5 +1,8 @@
 module UI.Colors exposing
-    ( darkGray
+    ( Colors
+    , black
+    , darkGray
+    , init
     , lightGray
     , lightPurple
     , purple
@@ -7,6 +10,23 @@ module UI.Colors exposing
     )
 
 import Element exposing (Color, rgb255)
+
+
+type alias Colors =
+    { backgroundColor : Color
+    , themeColor : Color
+    , fontColor : Color
+    , themeFontColor : Color
+    }
+
+
+init : Colors
+init =
+    { backgroundColor = white
+    , themeColor = lightPurple
+    , fontColor = black
+    , themeFontColor = black
+    }
 
 
 lightPurple : Color
@@ -24,11 +44,16 @@ white =
     rgb255 255 255 255
 
 
+lightGray : Color
+lightGray =
+    rgb255 200 200 200
+
+
 darkGray : Color
 darkGray =
     rgb255 50 50 50
 
 
-lightGray : Color
-lightGray =
-    rgb255 200 200 200
+black : Color
+black =
+    rgb255 0 0 0


### PR DESCRIPTION
This PR adds app theming pulled from manifests in the preview page. When a preview page is loaded, the manifest is read and the colors are synced to Shared to update the navbar and body colors.

The placeholder manifests were updated to give us some more interesting color themes to test with.