### PR TITLE
Add edit manifest page

### DIFF
--- a/src/Components/ManifestViewer.elm
+++ b/src/Components/ManifestViewer.elm
@@ -15,13 +15,18 @@ import UI.Colors as Colors
 import UI.Fonts as Fonts
 
 
-view : Manifest -> Element msg
-view manifest =
+view :
+    { manifest : Manifest
+    , fontColor : Color
+    }
+    -> Element msg
+view { manifest, fontColor } =
     column
         [ alignTop
         , width fill
         , padding 10
         , spacing 25
+        , Font.color fontColor
         ]
         [ row [ spacing 15 ]
             [ viewIcon { name = manifest.name, icons = manifest.icons }

--- a/src/Components/ManifestViewer.elm
+++ b/src/Components/ManifestViewer.elm
@@ -23,7 +23,7 @@ view :
 view { manifest, fontColor } =
     column
         [ alignTop
-        , width fill
+        , width (px 480)
         , padding 10
         , spacing 25
         , Font.color fontColor

--- a/src/Pages/Edit/AppShortName_String.elm
+++ b/src/Pages/Edit/AppShortName_String.elm
@@ -265,7 +265,10 @@ view model =
                                                     }
 
                                             NotEditing ->
-                                                ManifestViewer.view manifest
+                                                ManifestViewer.view
+                                                    { manifest = manifest
+                                                    , fontColor = model.colors.fontColor
+                                                    }
                                         , ManifestOutputs.view
                                             { manifest = manifest
                                             , onCopyToClipboard = CopyToClipboard
@@ -302,7 +305,10 @@ view model =
                                             }
 
                                     NotEditing ->
-                                        ManifestViewer.view manifest
+                                        ManifestViewer.view
+                                            { manifest = manifest
+                                            , fontColor = model.colors.fontColor
+                                            }
                                 , ManifestOutputs.view
                                     { manifest = manifest
                                     , onCopyToClipboard = CopyToClipboard

--- a/src/Pages/Preview/AppShortName_String.elm
+++ b/src/Pages/Preview/AppShortName_String.elm
@@ -150,13 +150,15 @@ view model =
                         [ width fill
                         , height fill
                         , paddingXY 10 20
-                        , Background.color model.colors.backgroundColor
-                        , Font.color model.colors.fontColor
                         ]
                     <|
                         case model.manifest of
                             Just manifest ->
-                                [ ManifestViewer.view manifest ]
+                                [ ManifestViewer.view
+                                    { manifest = manifest
+                                    , fontColor = model.colors.fontColor
+                                    }
+                                ]
 
                             Nothing ->
                                 [ none ]
@@ -169,13 +171,15 @@ view model =
                                 , height fill
                                 , paddingXY 10 20
                                 , spacing 20
-                                , Background.color model.colors.backgroundColor
-                                , Font.color model.colors.fontColor
                                 ]
                             <|
                                 case model.manifest of
                                     Just manifest ->
-                                        [ ManifestViewer.view manifest ]
+                                        [ ManifestViewer.view
+                                            { manifest = manifest
+                                            , fontColor = model.colors.fontColor
+                                            }
+                                        ]
 
                                     Nothing ->
                                         [ none ]
@@ -187,14 +191,15 @@ view model =
                                 , height fill
                                 , paddingXY 30 30
                                 , spacing 30
-                                , Background.color model.colors.backgroundColor
-                                , Font.color model.colors.fontColor
                                 ]
                             <|
                                 case model.manifest of
                                     Just manifest ->
                                         [ row [ width fill, spacing 25 ]
-                                            [ ManifestViewer.view manifest
+                                            [ ManifestViewer.view
+                                                { manifest = manifest
+                                                , fontColor = model.colors.fontColor
+                                                }
                                             , ManifestOutputs.view
                                                 { manifest = manifest
                                                 , onCopyToClipboard = CopyToClipboard
@@ -212,14 +217,15 @@ view model =
                         , height fill
                         , paddingXY 30 30
                         , spacing 30
-                        , Background.color model.colors.backgroundColor
-                        , Font.color model.colors.fontColor
                         ]
                     <|
                         case model.manifest of
                             Just manifest ->
                                 [ row [ width fill, spacing 25 ]
-                                    [ ManifestViewer.view manifest
+                                    [ ManifestViewer.view
+                                        { manifest = manifest
+                                        , fontColor = model.colors.fontColor
+                                        }
                                     , ManifestOutputs.view
                                         { manifest = manifest
                                         , onCopyToClipboard = CopyToClipboard


### PR DESCRIPTION
This PR adds the edit manifest page. This page toggles between showing the manifest editor and viewer. Manifest outputs are shown in both views. The page does not persist manifests yet.